### PR TITLE
Added support for schema configuration

### DIFF
--- a/plugin/src/main/scala/org/flywaydb/play/ConfigReader.scala
+++ b/plugin/src/main/scala/org/flywaydb/play/ConfigReader.scala
@@ -62,6 +62,8 @@ class ConfigReader(app: Application) extends UrlParser {
         app.configuration.getBoolean(s"db.${dbName}.migration.outOfOrder").getOrElse(false)
       val auto =
         app.configuration.getBoolean(s"db.${dbName}.migration.auto").getOrElse(false)
+      val schemas =
+        app.configuration.getString(s"db.${dbName}.migration.schemas")
 
       val database = DatabaseConfiguration(
         driver,
@@ -78,7 +80,8 @@ class ConfigReader(app: Application) extends UrlParser {
         placeholderPrefix,
         placeholderSuffix,
         placeholders,
-        outOfOrder
+        outOfOrder,
+        schemas
       )
     }).toMap
 

--- a/plugin/src/main/scala/org/flywaydb/play/FlywayConfiguration.scala
+++ b/plugin/src/main/scala/org/flywaydb/play/FlywayConfiguration.scala
@@ -24,7 +24,8 @@ case class FlywayConfiguration(
   placeholderPrefix: Option[String],
   placeholderSuffix: Option[String],
   placeholders: Map[String, String],
-  outOfOrder: Boolean)
+  outOfOrder: Boolean,
+  schemas: Option[String])
 
 case class DatabaseConfiguration(
   driver: String,

--- a/plugin/src/main/scala/org/flywaydb/play/PlayInitializer.scala
+++ b/plugin/src/main/scala/org/flywaydb/play/PlayInitializer.scala
@@ -65,6 +65,9 @@ class PlayInitializer @Inject() (implicit app: Application, webCommands: WebComm
       flyway.setValidateOnMigrate(configuration.validateOnMigrate)
       flyway.setEncoding(configuration.encoding)
       flyway.setOutOfOrder(configuration.outOfOrder)
+      for (schemas <- configuration.schemas) {
+        flyway.setSchemas(schemas)
+      }
       if (configuration.initOnMigrate) {
         flyway.setBaselineOnMigrate(true)
       }

--- a/plugin/src/test/scala/org/flywaydb/play/ConfigReaderSpec.scala
+++ b/plugin/src/test/scala/org/flywaydb/play/ConfigReaderSpec.scala
@@ -176,5 +176,19 @@ class ConfigReaderSpec extends FunSpec with ShouldMatchers {
       }
     }
 
+    
+    describe("schemas") {
+      it("should be parsed") {
+        withDefaultDB(Map("db.default.migration.schemas" -> "public, other")) { config =>
+          config.schemas should be(Some("public, other"))
+        }
+      }
+      it("should be None by default") {
+        withDefaultDB(Map.empty) { config =>
+          config.schemas should be(None)
+        }
+      }
+    }
+    
   }
 }


### PR DESCRIPTION
I wanted to use Flyway's schemas option in my Play app, but could not find the option in flyway-play.
As it turns out it was not there yet, so I propose to add it.
I am not sure if the schemas option should be set once for all databases or separately per database.
This pull requests has one setting for all databases.