### PR TITLE
Support optional configuration of multiple locations per database

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ CREATE TABLE FOO (.............
 
 ```
 
-Place your migration scripts in `conf/db/migration/${dbName}` .
+By default place your migration scripts in `conf/db/migration/${dbName}` .
 
 ```
 playapp
@@ -70,6 +70,46 @@ playapp
 │   │       ├── default
 │   │       │   ├── V1__Create_person_table.sql
 │   │       │   └── V2__Add_people.sql
+│   │       └── secondary
+│   │           ├── V1__create_job_table.sql
+│   │           └── V2__Add_job.sql
+│   ├── play.plugins
+│   └── routes
+```
+
+Alternatively, specify one or more locations per database and place your migrations in `conf/db/migration/${dbName}/${locations[1...N]}` .  By varying the locations in each environment you are able to specify different scripts per RDBMS for each upgrade.  These differences should be kept minimal.
+
+For example, in testing use the configuration:
+
+```
+db.default.migration.locations=["common","h2"]
+```
+
+And in production use the configuration:
+
+```
+db.default.migration.locations=["common","mysql"]
+```
+
+Then put your migrations in these folders. Note that the migrations for the `secondary` database remain in the default location.
+
+```
+playapp
+├── app
+│   ├── controllers
+│   ├── models
+│   └── views
+├── conf
+│   ├── application.conf
+│   ├── db
+│   │   └── migration
+│   │       ├── default
+│   │       │   ├── common
+│   │       │   │   └── V2__Add_people.sql
+│   │       │   ├── h2
+│   │       │   │   └── V1__Create_person_table.sql
+│   │       │   ├── mysql
+│   │       │   │   └── V1__Create_person_table.sql
 │   │       └── secondary
 │   │           ├── V1__create_job_table.sql
 │   │           └── V2__Add_job.sql

--- a/plugin/src/main/scala/org/flywaydb/play/ConfigReader.scala
+++ b/plugin/src/main/scala/org/flywaydb/play/ConfigReader.scala
@@ -70,6 +70,8 @@ class ConfigReader(configuration: Configuration, environment: Environment) {
         configuration.getBoolean(s"db.${dbName}.migration.auto").getOrElse(false)
       val schemas =
         configuration.getStringList(s"db.${dbName}.migration.schemas").getOrElse(java.util.Collections.emptyList[String]).asScala.toList
+      val locations =
+        configuration.getStringList(s"db.${dbName}.migration.locations").getOrElse(java.util.Collections.emptyList[String]).asScala.toList
 
       val database = DatabaseConfiguration(
         driver,
@@ -87,7 +89,8 @@ class ConfigReader(configuration: Configuration, environment: Environment) {
         placeholderSuffix,
         placeholders,
         outOfOrder,
-        schemas
+        schemas,
+        locations
       )
     }).toMap
 

--- a/plugin/src/main/scala/org/flywaydb/play/FlywayConfiguration.scala
+++ b/plugin/src/main/scala/org/flywaydb/play/FlywayConfiguration.scala
@@ -25,7 +25,8 @@ case class FlywayConfiguration(
   placeholderSuffix: Option[String],
   placeholders: Map[String, String],
   outOfOrder: Boolean,
-  schemas: List[String])
+  schemas: List[String],
+  locations: List[String])
 
 case class DatabaseConfiguration(
   driver: String,

--- a/plugin/src/main/scala/org/flywaydb/play/PlayInitializer.scala
+++ b/plugin/src/main/scala/org/flywaydb/play/PlayInitializer.scala
@@ -63,7 +63,12 @@ class PlayInitializer @Inject() (
       val flyway = new Flyway
       val database = configuration.database
       flyway.setDataSource(new DriverDataSource(getClass.getClassLoader, database.driver, database.url, database.user, database.password))
-      flyway.setLocations(migrationFilesLocation)
+      if (!configuration.locations.isEmpty) {
+        val locations = configuration.locations.map((location: String) => s"${migrationFilesLocation}/${location}"): List[String]
+        flyway.setLocations(locations: _*)
+      } else {
+        flyway.setLocations(migrationFilesLocation)
+      }
       flyway.setValidateOnMigrate(configuration.validateOnMigrate)
       flyway.setEncoding(configuration.encoding)
       flyway.setOutOfOrder(configuration.outOfOrder)

--- a/plugin/src/test/scala/org/flywaydb/play/ConfigReaderSpec.scala
+++ b/plugin/src/test/scala/org/flywaydb/play/ConfigReaderSpec.scala
@@ -187,5 +187,18 @@ class ConfigReaderSpec extends FunSpec with ShouldMatchers {
       }
     }
 
+    describe("locations") {
+      it("should be parsed") {
+        withDefaultDB(Map("db.default.migration.locations" -> List("h2", "common"))) { config =>
+          config.locations should be(List("h2", "common"))
+        }
+      }
+      it("should be None by default") {
+        withDefaultDB(Map.empty) { config =>
+          config.locations should be(List.empty)
+        }
+      }
+    }
+
   }
 }


### PR DESCRIPTION
Flyway supports variations in migration scripts per RDBMS by specifying one or more locations containing the migration scripts. For example, in test specifying ["h2", "common"] will use the union of the migration scripts between these two directories in the test environment. In production, one could then use ["mysql", "common"] and the h2 migrations steps would effectively be replaced with ones from the mysql location.

The differences between RDBMS should be kept minimal and most migration steps should be in the common folder. In fact, in most cases it is not even necessary to specify multiple locations. However, there are cases when using RDBMS specific functionality is necessary. One good example of this is full text indexing. The scripts to setup such indices are unfortunately RDBMS specific at this time.

e.g. Postgres
http://www.postgresql.org/docs/9.1/static/textsearch-tables.html

e.g. H2
http://www.h2database.com/html/tutorial.html#fulltext

Specifying multiple locations was specifically developed in Flyway to address such issues:

http://flywaydb.org/documentation/faq.html#db-specific-sql

This change uses the default location of `conf/db/migration/${dbname}` unless the `db.${dbname}.migration.locations` list is non-empty in which case the list of locations is combined with the default location to create the list of location for Flyway as: `[conf/db/migration/${dbname}/${location[0]}, conf/db/migration/${dbname}/${location[1]}, ..., conf/db/migration/${dbname}//${location[N]}]`.