### PR TITLE
FlywayPlayComponents for compile time DI

### DIFF
--- a/plugin/src/main/scala/org/flywaydb/play/FlywayPlayComponents.scala
+++ b/plugin/src/main/scala/org/flywaydb/play/FlywayPlayComponents.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2013 Toshiyuki Takahashi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.flywaydb.play
+
+import play.api._
+import play.core._
+
+trait FlywayPlayComponents {
+  def configuration: Configuration
+  def environment: Environment
+  def webCommands: WebCommands
+
+  lazy val playInitializer = new PlayInitializer(configuration, environment, webCommands)
+}


### PR DESCRIPTION
I just added a trait to mixin with a custom ApplicationLoader in Play to support compile time dependency injection.   Fixes #15 

Since this is a `lazy val` to make sure that migrations are running, referencing the `playInitializer` in the `ApplicationLoader` is necessary.

```scala
class MyComponents(context: Context) extends BuiltInComponents(context) with FlywayPlayComponents {
  playInitializer
  ...
}
```

Let me know if I can help otherwise with testing or adding an extra test to the existing one.  I can look into it as well, but I checked this with my own app and it worked splendidly.

I would be happy to add another test with a custom application loader though, just let me know!