### PR TITLE
Adding insert query for manual flyway migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,15 @@ Custom sql migration prefix key-value pair can be specified in application.conf:
 db.${dbName}.migration.sqlMigrationPrefix="migration_"
 ```
 
+### Insert Query
+
+If you want to apply your migration not via the web interface, but manually on
+your production databases you also need the valid insert query for flyway.
+
+```
+db.${dbName}.migration.showInsertQuery=true
+```
+
 ### Dev
 
 ![screenshot](screenshot1.png)

--- a/playapp/conf/application.conf
+++ b/playapp/conf/application.conf
@@ -41,6 +41,7 @@ db.secondary.driver=org.h2.Driver
 db.secondary.url="jdbc:h2:mem:example2;db_CLOSE_DELAY=-1"
 db.secondary.user="sa"
 db.secondary.password="secret"
+db.secondary.migration.showInsertQuery=true
 
 db.third.driver=org.h2.Driver
 db.third.url="jdbc:h2:mem:example3;DB_CLOSE_DELAY=-1"


### PR DESCRIPTION
This addition provides the web interface with an additional insert query for the flyway.
If you want/have-to apply your db migrations manually on your production database you also have to migrate the flyway `schema_table`.

![image](https://cloud.githubusercontent.com/assets/647727/12849977/ae571e06-cc22-11e5-9511-9899641606a4.png)
