### PR TITLE
Added mixed configuration parameter

### DIFF
--- a/plugin/src/main/scala/org/flywaydb/play/ConfigReader.scala
+++ b/plugin/src/main/scala/org/flywaydb/play/ConfigReader.scala
@@ -69,7 +69,7 @@ class ConfigReader(configuration: Configuration, environment: Environment) {
         subConfig.getOptional[Boolean]("initOnMigrate"),
         subConfig.getOptional[Boolean]("outOfOrder"),
         subConfig.getOptional[String]("scriptsDirectory"),
-        subConfig.getOptional[String]("mixed"))
+        subConfig.getOptional[Boolean]("mixed"))
     }).toMap
   }
 

--- a/plugin/src/main/scala/org/flywaydb/play/ConfigReader.scala
+++ b/plugin/src/main/scala/org/flywaydb/play/ConfigReader.scala
@@ -68,7 +68,8 @@ class ConfigReader(configuration: Configuration, environment: Environment) {
         subConfig.getOptional[Boolean]("cleanDisabled"),
         subConfig.getOptional[Boolean]("initOnMigrate"),
         subConfig.getOptional[Boolean]("outOfOrder"),
-        subConfig.getOptional[String]("scriptsDirectory"))
+        subConfig.getOptional[String]("scriptsDirectory"),
+        subConfig.getOptional[String]("mixed"))
     }).toMap
   }
 

--- a/plugin/src/main/scala/org/flywaydb/play/FlywayConfiguration.scala
+++ b/plugin/src/main/scala/org/flywaydb/play/FlywayConfiguration.scala
@@ -39,7 +39,8 @@ case class FlywayConfiguration(
   cleanDisabled: Option[Boolean],
   initOnMigrate: Option[Boolean],
   outOfOrder: Option[Boolean],
-  scriptsDirectory: Option[String])
+  scriptsDirectory: Option[String],
+  mixed: Option[Boolean])
 
 case class DatabaseConfiguration(
   driver: String,

--- a/plugin/src/main/scala/org/flywaydb/play/Flyways.scala
+++ b/plugin/src/main/scala/org/flywaydb/play/Flyways.scala
@@ -80,6 +80,7 @@ class Flyways @Inject() (
       configuration.cleanDisabled.foreach(flyway.cleanDisabled)
       configuration.initOnMigrate.foreach(flyway.baselineOnMigrate)
       configuration.outOfOrder.foreach(flyway.outOfOrder)
+      configuration.mixed.foreach(flyway.mixed)
 
       dbName -> flyway.load()
     }

--- a/plugin/src/test/scala/org/flywaydb/play/ConfigReaderSpec.scala
+++ b/plugin/src/test/scala/org/flywaydb/play/ConfigReaderSpec.scala
@@ -335,5 +335,18 @@ class ConfigReaderSpec extends FunSpec with Matchers {
       }
     }
 
+    describe("mixed") {
+      it("should be parsed") {
+        withDefaultDB(Map("db.default.migration.mixed" -> "true")) { config =>
+          config.mixed should be(Some(true))
+        }
+      }
+      it("should be None by default") {
+        withDefaultDB(Map.empty) { config =>
+          config.mixed should be(None)
+        }
+      }
+    }
+
   }
 }


### PR DESCRIPTION
Added the flyway configuration parameter: **mixed** that allows mixing transactional and non-transactional statements within the same migration.