### PR TITLE
Add config prefix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,25 +1,48 @@
+import sbt.Keys.resolvers
+
 val scalaVersion_2_11 = "2.11.12"
-val scalaVersion_2_12 = "2.12.8"
+val scalaVersion_2_12 = "2.12.10"
 val scalaVersion_2_13 = "2.13.0"
 
 val flywayVersion = "6.0.1"
-val flywayPlayVersion = "5.4.0"
+val flywayPlayVersion = "5.4.101"
 val scalikejdbcVersion = "3.3.5"
 
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 
-lazy val commonSettings = Seq(
-  organization := "org.flywaydb",
-  scalaVersion := scalaVersion_2_11,
-  crossScalaVersions := Seq(scalaVersion_2_11, scalaVersion_2_12, scalaVersion_2_13),
+lazy val sArtSettings = Seq(
+  organization := "com.sa",
+  resolvers += "Nexus Releases" at "https://nexus.s-art.co.nz/repository/maven-releases",
+  resolvers += "Nexus Snapshots" at "https://nexus.s-art.co.nz/repository/maven-snapshots",
   publishTo := {
-    val nexus = "https://oss.sonatype.org/"
-    if (version.value.trim.endsWith("SNAPSHOT"))
-      Some("snapshots" at nexus + "content/repositories/snapshots")
+    val nexus = "https://nexus.s-art.co.nz/"
+    if (isSnapshot.value)
+      Some("snapshots" at nexus + "repository/maven-snapshots")
     else
-      Some("releases" at nexus + "service/local/staging/deploy/maven2")
-  }
+      Some("releases" at nexus + "repository/maven-releases")
+  },
+  credentials += Credentials(Path.userHome / ".ivy2" / ".credentials.sa")
 )
+
+lazy val fpSettings = Seq(
+  organization := "com.mattgilbert",
+  resolvers += "Nexus Releases" at "https://nexus.financialplatforms.co.nz/nexus/content/repositories/releases",
+  resolvers += "Nexus Snapshots" at "https://nexus.financialplatforms.co.nz/nexus/content/repositories/snapshots",
+  publishTo := {
+    val nexus = "https://nexus.financialplatforms.co.nz/nexus/content/repositories/"
+    if (isSnapshot.value)
+      Some("snapshots" at nexus + "snapshots")
+    else
+      Some("releases" at nexus + "releases")
+  },
+  credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
+)
+
+lazy val commonSettings = Seq(
+  organization := "com.sa",
+  scalaVersion := scalaVersion_2_12,
+  // crossScalaVersions := Seq(scalaVersion_2_11, scalaVersion_2_12, scalaVersion_2_13),
+) ++ sArtSettings
 
 lazy val `flyway-play` = project.in(file("."))
   .settings(commonSettings)
@@ -34,7 +57,7 @@ lazy val plugin = project.in(file("plugin"))
     Seq(
       name := "flyway-play",
       version := flywayPlayVersion,
-      resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",
+      resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/",
       libraryDependencies ++= Seq(
         "com.typesafe.play" %% "play" % play.core.PlayVersion.current % "provided",
         "com.typesafe.play" %% "play-test" % play.core.PlayVersion.current % "test"
@@ -73,6 +96,7 @@ lazy val playapp = project.in(file("playapp"))
 val publishingSettings = Seq(
   publishMavenStyle := true,
   publishArtifact in Test := false,
+  publishArtifact in(Compile, packageDoc) := false,
   pomExtra :=
     <url>https://github.com/flyway/flyway-play</url>
       <licenses>

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ val scalaVersion_2_12 = "2.12.10"
 val scalaVersion_2_13 = "2.13.0"
 
 val flywayVersion = "6.0.1"
-val flywayPlayVersion = "5.4.101"
+val flywayPlayVersion = "5.4.102"
 val scalikejdbcVersion = "3.3.5"
 
 val scalatest = "org.scalatest" %% "scalatest" % "3.0.8" % "test"

--- a/plugin/src/main/scala/org/flywaydb/play/Flyways.scala
+++ b/plugin/src/main/scala/org/flywaydb/play/Flyways.scala
@@ -33,6 +33,8 @@ class Flyways @Inject() (
 
   val flywayPrefixToMigrationScript: String = "db/migration"
 
+  private val logger = Logger(classOf[Flyways])
+
   private val flywayConfigurations = {
     val configReader = new ConfigReader(configuration, environment)
     configReader.getFlywayConfigurations
@@ -124,11 +126,11 @@ class Flyways @Inject() (
   private def migrationFileDirectoryExists(path: String): Boolean = {
     environment.resource(path) match {
       case Some(_) =>
-        Logger.debug(s"Directory for migration files found. $path")
+        logger.debug(s"Directory for migration files found. $path")
         true
 
       case None =>
-        Logger.warn(s"Directory for migration files not found. $path")
+        logger.warn(s"Directory for migration files not found. $path")
         false
 
     }
@@ -136,7 +138,7 @@ class Flyways @Inject() (
 
   private def setSqlMigrationSuffixes(configuration: FlywayConfiguration, flyway: FluentConfiguration): Unit = {
     configuration.sqlMigrationSuffix.foreach(_ =>
-      Logger.warn("sqlMigrationSuffix is deprecated in Flyway 5.0, and will be removed in a future version. Use sqlMigrationSuffixes instead."))
+      logger.warn("sqlMigrationSuffix is deprecated in Flyway 5.0, and will be removed in a future version. Use sqlMigrationSuffixes instead."))
     val suffixes: Seq[String] = configuration.sqlMigrationSuffixes ++ configuration.sqlMigrationSuffix
     if (suffixes.nonEmpty) flyway.sqlMigrationSuffixes(suffixes: _*)
   }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.2

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.2
+sbt.version=1.3.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,10 @@
 // The Typesafe repository
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.3")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.4.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.5.0")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 


### PR DESCRIPTION
I would like to be able to change the config prefix from the default db.<name>... to something else.

This is to resolve an issue I'm having where an extra connection pool is being created.

Using Play 2.7.3 + PlaySlick, Slick creates the connection pool that we want to use.

However, if I define my db config for flyway with the normal `db.default` config then Play creates a second unwanted connection pool.

My workaround at the moment is to go from this
```
db.default {
  driver = org.postgresql.Driver
  username = "username"
  password = "password"
  url = "jdbc:postgresql://host/dbname"
}

slick.dbs.default.profile="slick.jdbc.PostgresProfile$"
slick.dbs.default.driver = "slick.driver.PostgresDriver$"
slick.dbs.default.db {
  properties.driver = "org.postgresql.Driver"
  properties.url = "postgresql://username:password@host/dbname"
  dataSourceClass="slick.jdbc.DatabaseUrlDataSource"
}
```

to this

```
flyway-config = "flyway"

flyway.default {
  driver = org.postgresql.Driver
  username = "username"
  password = "password"
  url = "jdbc:postgresql://host/dbname"
}

slick.dbs.default.profile="slick.jdbc.PostgresProfile$"
slick.dbs.default.driver = "slick.driver.PostgresDriver$"
slick.dbs.default.db {
  properties.driver = "org.postgresql.Driver"
  properties.url = "postgresql://username:password@host/dbname"
  dataSourceClass="slick.jdbc.DatabaseUrlDataSource"
}
```

This is just an example solution, open to any and all input.
