### PR TITLE
Update play to 2.8.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-val scalaVersion_2_11 = "2.11.12"
 val scalaVersion_2_12 = "2.12.8"
 val scalaVersion_2_13 = "2.13.0"
 
@@ -10,8 +9,8 @@ val scalatest = "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 
 lazy val commonSettings = Seq(
   organization := "org.flywaydb",
-  scalaVersion := scalaVersion_2_11,
-  crossScalaVersions := Seq(scalaVersion_2_11, scalaVersion_2_12, scalaVersion_2_13),
+  scalaVersion := scalaVersion_2_12,
+  crossScalaVersions := Seq(scalaVersion_2_12, scalaVersion_2_13),
   publishTo := {
     val nexus = "https://oss.sonatype.org/"
     if (version.value.trim.endsWith("SNAPSHOT"))

--- a/plugin/src/main/scala/org/flywaydb/play/Flyways.scala
+++ b/plugin/src/main/scala/org/flywaydb/play/Flyways.scala
@@ -33,6 +33,8 @@ class Flyways @Inject() (
 
   val flywayPrefixToMigrationScript: String = "db/migration"
 
+  val logger = Logger(classOf[Flyways])
+
   private val flywayConfigurations = {
     val configReader = new ConfigReader(configuration, environment)
     configReader.getFlywayConfigurations
@@ -124,11 +126,11 @@ class Flyways @Inject() (
   private def migrationFileDirectoryExists(path: String): Boolean = {
     environment.resource(path) match {
       case Some(_) =>
-        Logger.debug(s"Directory for migration files found. $path")
+        logger.debug(s"Directory for migration files found. $path")
         true
 
       case None =>
-        Logger.warn(s"Directory for migration files not found. $path")
+        logger.warn(s"Directory for migration files not found. $path")
         false
 
     }
@@ -136,7 +138,7 @@ class Flyways @Inject() (
 
   private def setSqlMigrationSuffixes(configuration: FlywayConfiguration, flyway: FluentConfiguration): Unit = {
     configuration.sqlMigrationSuffix.foreach(_ =>
-      Logger.warn("sqlMigrationSuffix is deprecated in Flyway 5.0, and will be removed in a future version. Use sqlMigrationSuffixes instead."))
+      logger.warn("sqlMigrationSuffix is deprecated in Flyway 5.0, and will be removed in a future version. Use sqlMigrationSuffixes instead."))
     val suffixes: Seq[String] = configuration.sqlMigrationSuffixes ++ configuration.sqlMigrationSuffix
     if (suffixes.nonEmpty) flyway.sqlMigrationSuffixes(suffixes: _*)
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.3")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.4.2")
 


### PR DESCRIPTION
Play 2.8 removes support for Scala 2.11 and almost all methods of the play.api.Logger singleton object.