### PR TITLE
Add 'group' configuration parameter

### DIFF
--- a/plugin/src/main/scala/org/flywaydb/play/ConfigReader.scala
+++ b/plugin/src/main/scala/org/flywaydb/play/ConfigReader.scala
@@ -69,7 +69,8 @@ class ConfigReader(configuration: Configuration, environment: Environment) {
         subConfig.getOptional[Boolean]("initOnMigrate"),
         subConfig.getOptional[Boolean]("outOfOrder"),
         subConfig.getOptional[String]("scriptsDirectory"),
-        subConfig.getOptional[Boolean]("mixed"))
+        subConfig.getOptional[Boolean]("mixed"),
+        subConfig.getOptional[Boolean]("group"))
     }).toMap
   }
 

--- a/plugin/src/main/scala/org/flywaydb/play/FlywayConfiguration.scala
+++ b/plugin/src/main/scala/org/flywaydb/play/FlywayConfiguration.scala
@@ -40,7 +40,8 @@ case class FlywayConfiguration(
   initOnMigrate: Option[Boolean],
   outOfOrder: Option[Boolean],
   scriptsDirectory: Option[String],
-  mixed: Option[Boolean])
+  mixed: Option[Boolean],
+  group: Option[Boolean])
 
 case class DatabaseConfiguration(
   driver: String,

--- a/plugin/src/main/scala/org/flywaydb/play/Flyways.scala
+++ b/plugin/src/main/scala/org/flywaydb/play/Flyways.scala
@@ -81,6 +81,7 @@ class Flyways @Inject() (
       configuration.initOnMigrate.foreach(flyway.baselineOnMigrate)
       configuration.outOfOrder.foreach(flyway.outOfOrder)
       configuration.mixed.foreach(flyway.mixed)
+      configuration.group.foreach(flyway.group)
 
       dbName -> flyway.load()
     }

--- a/plugin/src/test/scala/org/flywaydb/play/ConfigReaderSpec.scala
+++ b/plugin/src/test/scala/org/flywaydb/play/ConfigReaderSpec.scala
@@ -348,5 +348,17 @@ class ConfigReaderSpec extends FunSpec with Matchers {
       }
     }
 
+    describe("group") {
+      it("should be parsed") {
+        withDefaultDB(Map("db.default.migration.group" -> "true")) { config =>
+          config.group should be(Some(true))
+        }
+      }
+      it("should be None by default") {
+        withDefaultDB(Map.empty) { config =>
+          config.group should be(None)
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Hi @tototoshi,

this pull request adds the configuration parameter `group` which enables to group multiple pending migrations in a single transaction. 

Copied from [flyway documentation](https://flywaydb.org/documentation/configfiles#reference):

```hocon
# Whether to group all pending migrations together in the same transaction when applying them
# (only recommended for databases with support for DDL transactions).
# true if migrations should be grouped. false if they should be applied individually instead. (default: false)
# flyway.group=
```

Cheers