### PR TITLE
Add optional config prefix setting

### DIFF
--- a/plugin/src/main/scala/org/flywaydb/play/ConfigReader.scala
+++ b/plugin/src/main/scala/org/flywaydb/play/ConfigReader.scala
@@ -25,8 +25,11 @@ class ConfigReader(configuration: Configuration, environment: Environment) {
 
   val logger = Logger(classOf[ConfigReader])
 
+  private def dbConfigPrefix: String =
+    configuration.getOptional[String]("flyway-config").getOrElse("db")
+
   private def getAllDatabaseNames: Seq[String] = (for {
-    config <- configuration.getOptional[Configuration]("db").toList
+    config <- configuration.getOptional[Configuration](dbConfigPrefix).toList
     dbName <- config.subKeys
   } yield {
     dbName
@@ -36,7 +39,7 @@ class ConfigReader(configuration: Configuration, environment: Environment) {
     (for {
       dbName <- getAllDatabaseNames
       database <- getDatabaseConfiguration(configuration, dbName)
-      subConfig = configuration.getOptional[Configuration](s"db.$dbName.migration").getOrElse(Configuration.empty)
+      subConfig = configuration.getOptional[Configuration](s"$dbConfigPrefix.$dbName.migration").getOrElse(Configuration.empty)
     } yield {
       val placeholders = {
         subConfig.getOptional[Configuration]("placeholders").map { config =>
@@ -76,17 +79,17 @@ class ConfigReader(configuration: Configuration, environment: Environment) {
 
   private def getDatabaseConfiguration(configuration: Configuration, dbName: String): Option[DatabaseConfiguration] = {
     val jdbcConfigOrError = for {
-      jdbcUrl <- configuration.getOptional[String](s"db.$dbName.url").toRight(s"db.$dbName.url is not set").right
-      driver <- configuration.getOptional[String](s"db.$dbName.driver").toRight(s"db.$dbName.driver is not set").right
+      jdbcUrl <- configuration.getOptional[String](s"$dbConfigPrefix.$dbName.url").toRight(s"$dbConfigPrefix.$dbName.url is not set").right
+      driver <- configuration.getOptional[String](s"$dbConfigPrefix.$dbName.driver").toRight(s"$dbConfigPrefix.$dbName.driver is not set").right
     } yield {
       val (parsedUrl, parsedUser, parsedPass) = urlParser.parseUrl(jdbcUrl)
       val username = parsedUser
-        .orElse(configuration.getOptional[String](s"db.$dbName.username"))
-        .orElse(configuration.getOptional[String](s"db.$dbName.user"))
+        .orElse(configuration.getOptional[String](s"$dbConfigPrefix.$dbName.username"))
+        .orElse(configuration.getOptional[String](s"$dbConfigPrefix.$dbName.user"))
         .orNull
       val password = parsedPass
-        .orElse(configuration.getOptional[String](s"db.$dbName.password"))
-        .orElse(configuration.getOptional[String](s"db.$dbName.pass"))
+        .orElse(configuration.getOptional[String](s"$dbConfigPrefix.$dbName.password"))
+        .orElse(configuration.getOptional[String](s"$dbConfigPrefix.$dbName.pass"))
         .orNull
       JdbcConfig(driver, parsedUrl, username, password)
     }


### PR DESCRIPTION
I would like to be able to change the config prefix from the default db.<name>... to something else.

This is to resolve an issue I'm having where an extra connection pool is being created.

Using Play 2.7.3 + PlaySlick, Slick creates the connection pool that we want to use.

However, if I define my db config for flyway with the normal `db.default` config then Play creates a second unwanted connection pool.

My workaround at the moment is to go from this
```
db.default {
  driver = org.postgresql.Driver
  username = "username"
  password = "password"
  url = "jdbc:postgresql://host/dbname"
}

slick.dbs.default.profile="slick.jdbc.PostgresProfile$"
slick.dbs.default.driver = "slick.driver.PostgresDriver$"
slick.dbs.default.db {
  properties.driver = "org.postgresql.Driver"
  properties.url = "postgresql://username:password@host/dbname"
  dataSourceClass="slick.jdbc.DatabaseUrlDataSource"
}
```

to this

```
flyway-config = "flyway"

flyway.default {
  driver = org.postgresql.Driver
  username = "username"
  password = "password"
  url = "jdbc:postgresql://host/dbname"
}

slick.dbs.default.profile="slick.jdbc.PostgresProfile$"
slick.dbs.default.driver = "slick.driver.PostgresDriver$"
slick.dbs.default.db {
  properties.driver = "org.postgresql.Driver"
  properties.url = "postgresql://username:password@host/dbname"
  dataSourceClass="slick.jdbc.DatabaseUrlDataSource"
}
```

This is just an example solution, open to any and all input.
