### PR TITLE
fix warning. avoid `Either#right`

### DIFF
--- a/plugin/src/main/scala/org/flywaydb/play/ConfigReader.scala
+++ b/plugin/src/main/scala/org/flywaydb/play/ConfigReader.scala
@@ -76,8 +76,8 @@ class ConfigReader(configuration: Configuration, environment: Environment) {
 
   private def getDatabaseConfiguration(configuration: Configuration, dbName: String): Option[DatabaseConfiguration] = {
     val jdbcConfigOrError = for {
-      jdbcUrl <- configuration.getOptional[String](s"db.$dbName.url").toRight(s"db.$dbName.url is not set").right
-      driver <- configuration.getOptional[String](s"db.$dbName.driver").toRight(s"db.$dbName.driver is not set").right
+      jdbcUrl <- configuration.getOptional[String](s"db.$dbName.url").toRight(s"db.$dbName.url is not set")
+      driver <- configuration.getOptional[String](s"db.$dbName.driver").toRight(s"db.$dbName.driver is not set")
     } yield {
       val (parsedUrl, parsedUser, parsedPass) = urlParser.parseUrl(jdbcUrl)
       val username = parsedUser


### PR DESCRIPTION
```
[warn] /home/runner/work/flyway-play/flyway-play/plugin/src/main/scala/org/flywaydb/play/ConfigReader.scala:79:109: method right in class Either is deprecated (since 2.13.0): Either is now right-biased, use methods directly on Either
[warn]       jdbcUrl <- configuration.getOptional[String](s"db.$dbName.url").toRight(s"db.$dbName.url is not set").right
[warn]                                                                                                             ^
[warn] /home/runner/work/flyway-play/flyway-play/plugin/src/main/scala/org/flywaydb/play/ConfigReader.scala:80:114: method right in class Either is deprecated (since 2.13.0): Either is now right-biased, use methods directly on Either
[warn]       driver <- configuration.getOptional[String](s"db.$dbName.driver").toRight(s"db.$dbName.driver is not set").right
[warn]                                                                                                                  ^
```